### PR TITLE
Remove defunct Heroku API integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,21 +22,8 @@
   ga('send', 'pageview');
   
   
-      var guid = (function() {
-        function s4() {
-          return Math.floor((1 + Math.random()) * 0x10000)
-                     .toString(16)
-                     .substring(1);
-        }
-        return function() {
-          return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
-                 s4() + '-' + s4() + s4() + s4();
-        };
-      })();
-            
-           
       window.onload = function() {
-       var js = "javascript:(function(){s=document.createElement('script');s.type='text/javascript';s.onload=function(){getServerSettings('"+guid()+"');};s.src='https://trochr.github.io/ScrollStuff/smartscroll.js?v='+parseInt(Math.random()*99999999);document.body.appendChild(s);})();";
+        var js = "javascript:(function(){s=document.createElement('script');s.type='text/javascript';s.src='https://trochr.github.io/ScrollStuff/smartscroll.js?v='+parseInt(Math.random()*99999999);document.body.appendChild(s);})();";
         document.getElementById("bmlet").setAttribute("href",js);
         document.getElementById("bmprecode").innerHTML = js;
         document.getElementById('showcode').onclick =

--- a/smartscroll.js
+++ b/smartscroll.js
@@ -9,13 +9,9 @@ var asSettings = {wordsReadPerMinute: 180,
     curElm: null,
     debugInvokeDelay: 200,
     lastEscPressTime: 0,
-    saveInterval: null,
     totalWords: 0,
-    guid: null,
     completion: null,
     ps: null};
-
-var APIUrl = "https://fierce-escarpment-8017.herokuapp.com";
 
 function getAllPs() {
   'use strict';
@@ -100,32 +96,6 @@ function unloadAS() {
   document.getElementById('smartscrollbanner').remove();
 }
 
-
-function getServerSettings(guid) {
-  'use strict';
-  if (document.getElementById('wpm') === null) {
-    return;
-  }
-  asSettings.guid = guid;
-  var http = new window.XMLHttpRequest(),
-    url = APIUrl+"/user/settings";
-  http.open("GET", url, true);
-  http.setRequestHeader("Authorization", guid);
-
-  http.onreadystatechange = function () { //Call a function when the state changes.
-    if (http.readyState === 4 && http.status === 200) {
-      var resp = JSON.parse(http.responseText);
-      if (!resp.hasOwnProperty('wpm')) {
-        return;
-      }
-      if (Math.floor(resp.wpm) > 0) {
-        asSettings.wordsReadPerMinute = resp.wpm;
-        document.getElementById('wpm').innerHTML = resp.wpm;
-      }
-    }
-  };
-  http.send(null);
-}
 
 
 function revealStatus(ds) {
@@ -322,23 +292,10 @@ function pauseScroll() {
   }
 }
 
-function saveSettings() {
-  'use strict';
-  var http = new window.XMLHttpRequest(),
-    url = APIUrl+"/user/settings",
-    params = "wpm=" + asSettings.wordsReadPerMinute;
-  http.open("POST", url, true);
-  http.setRequestHeader("Authorization", asSettings.guid);
-  http.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-  http.send(params);
-}
-
 function wpmChanged() {
   'use strict';
   document.getElementById('wpm').innerText = asSettings.wordsReadPerMinute;
-  window.clearInterval(asSettings.saveInterval);
   onP(asSettings.curElm);
-  asSettings.saveInterval = window.setTimeout(function () {saveSettings(); }, 2000);
 }
 
 function setupPlusMinus() {


### PR DESCRIPTION
The Heroku app (fierce-escarpment-8017) is no longer running, so all server-side WPM persistence is dead code. This removes APIUrl, getServerSettings(), saveSettings(), the guid machinery in index.html, and the saveInterval/guid fields from asSettings. The WPM +/- controls in the overlay still work; they just no longer attempt to persist changes to a backend.

https://claude.ai/code/session_018sTdXS6sbGwwSqemP3xa8V